### PR TITLE
use random value for temporary component ID

### DIFF
--- a/draft-ietf-mls-virtual-clients.md
+++ b/draft-ietf-mls-virtual-clients.md
@@ -1466,7 +1466,7 @@ object in which the component appears:
 
 The requested registration is:
 
-- Value: 0x0006 (suggested)
+- Value: 0x667A (temporary)
 - Name: virtual_clients
 - Where: GI, LN, AD, ES
 - Recommended: Y


### PR DESCRIPTION
To avoid collisions during implementation testing we should choose a random ID. The current value collides with the component ID of the [APQMLS combiner](https://datatracker.ietf.org/doc/draft-ietf-mls-combiner/).